### PR TITLE
Fix Vercel framework value

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "framework": "static",
+  "framework": "nextjs",
   "rewrites": [
     { "source": "/(.*)", "destination": "/" }
   ]


### PR DESCRIPTION
## Summary
- update `framework` to `nextjs` for Vercel configuration

## Testing
- `npm run build` *(fails: next not found)*