### PR TITLE
Fix module script MIME type error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,3 @@
 {
-  "framework": "nextjs",
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/" }
-  ]
+  "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- remove universal rewrite rule from Vercel config so static JS files are served

## Testing
- `npm run build` *(fails: `next` not found)*